### PR TITLE
Launchpad midimap update for playing_inaudible

### DIFF
--- a/midimaps/novation-launchpad-s.giadamap
+++ b/midimaps/novation-launchpad-s.giadamap
@@ -1,6 +1,6 @@
 {
   "brand": "Novation",
-  "device": "Launchpad S",
+  "device": "Launchpad S / Mini",
   "init_commands": [
     {
       "channel": 0,
@@ -9,6 +9,10 @@
     {
       "channel": 0,
       "message": "0xB0002800"
+    }
+    {
+      "channel": 0,
+      "message": "0xB01E0F00"
     }
   ],
   "mute_on": {
@@ -34,6 +38,10 @@
   "playing": {
     "channel": 0,
     "message": "0x90nn3C00"
+  },
+  "playing_inaudible": {
+    "channel": 0,
+    "message": "0x90nn1C00"
   },
   "stopping": {
     "channel": 0,


### PR DESCRIPTION
Also, an extra init command to improve contrast on Launchpad controllers.

All the changes were based on Launchpad S documentation and tested on Launchpad Mini, so I assumed that changing "device" field makes sense since we expect both to work with these changes.