### PR TITLE
A Korg nanoKONTROL 2 configuration

### DIFF
--- a/midimaps/korg-nanokontrol2.giadamap
+++ b/midimaps/korg-nanokontrol2.giadamap
@@ -1,0 +1,46 @@
+{
+	"brand": "Korg",
+	"device": "nanoKONTROL 2",
+	"init_commands": [
+		{
+			"channel": 0,
+			"message": "0xBF297f00"
+		},
+		{
+			"channel": 0,
+			"message": "0xBF297f00"
+		}
+	],
+	"mute_on": {
+		"channel": 0,
+		"message": "0xB0nn7f00"
+	},
+	"mute_off": {
+		"channel": 0,
+		"message": "0xB0nn0000"
+	},
+	"solo_on": {
+		"channel": 0,
+		"message": "0xB0nn7F00"
+	},
+	"solo_off": {
+		"channel": 0,
+		"message": "0xB0nn0000"
+	},
+	"waiting": {
+		"channel": 0,
+		"message": "0xB0nn0000"
+	},
+	"playing": {
+		"channel": 0,
+		"message": "0xB0nn7f00"
+	},
+	"stopping": {
+		"channel": 0,
+		"message": "0xB0nn6400"
+	},
+	"stopped": {
+		"channel": 0,
+		"message": "0xB0nn0000"
+	}
+}


### PR DESCRIPTION
Spent some time getting my nanoKONTROL 2 LEDs working. All the controls on the surface work fine, and all the control group LEDs work as expected when hooked up with MIDI-out and lighting enabled, but while the surface does have other LEDs there didn't seem to be a way to map the playback/track/cycle/marker groups to anything in Giada, so I've left those alone.